### PR TITLE
Added `UNION (ALL)` support and stuff descibed below

### DIFF
--- a/src/distinct.rs
+++ b/src/distinct.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 pub enum DistinctType<'a> {
     Empty,
     Simple,

--- a/src/for_cl.rs
+++ b/src/for_cl.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 pub enum ForMode {
     Update,
     Share
@@ -40,6 +41,7 @@ impl<'a> For<'a> {
     }
 }
 
+#[allow(dead_code)]
 pub enum ForType<'a> {
     Empty,
     Specified(&'a For<'a>)

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,4 +1,5 @@
 // TODO: add cross join
+#[allow(dead_code)]
 pub enum JoinType {
     Inner,
     Left,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unused_features)]
 #![feature(test)]
 mod query;
 mod select;
@@ -8,3 +9,4 @@ mod distinct;
 mod limit;
 mod offset;
 mod for_cl;
+mod union;

--- a/src/limit.rs
+++ b/src/limit.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 pub enum LimitType<'a> {
     Empty,
     Specified(&'a str)

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 pub enum OffsetType<'a> {
     Empty,
     Specified(&'a str)

--- a/src/order_by.rs
+++ b/src/order_by.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 pub enum Ordering {
     Ascending,
     Descending,

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 pub enum SelectType<'a> {
     All,
     Specific(&'a [&'a str])

--- a/src/union.rs
+++ b/src/union.rs
@@ -1,0 +1,148 @@
+use query::ToSQL;
+
+#[allow(dead_code)]
+enum UnionType {
+    Simple,
+    All
+}
+
+#[allow(dead_code)]
+struct Union<L: ToSQL, R: ToSQL> {
+    left: L,
+    right: R,
+    mode: UnionType
+}
+
+impl<L: ToSQL, R: ToSQL> ToSQL for Union<L, R> {
+    fn to_sql(&self) -> String {
+        let mut rv = String::new();
+        rv.push_str(&self.left.to_sql());
+        rv.push(' ');
+        rv.push_str("UNION");
+        rv.push(' ');
+
+        if let UnionType::All = self.mode {
+            rv.push_str("ALL");
+            rv.push(' ');
+        }
+        
+        rv.push_str(&self.right.to_sql());
+        rv
+    }
+}
+
+impl<'a, L: ToSQL, R:ToSQL> ToSQL for &'a Union<L, R> {
+    fn to_sql(&self) -> String {
+        (**self).to_sql()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Union, UnionType};
+    use query::{ToSQL, Query};
+    use select::SelectType;
+    use where_cl::WhereType;
+    use distinct::DistinctType;
+    use limit::LimitType;
+    use offset::OffsetType;
+    use for_cl::ForType;
+
+    #[test]
+    fn test_simple() {
+        let query = Query {
+            select: SelectType::All,
+            distinct: DistinctType::Empty,
+            from: "test_table",
+            joins: &[],
+            group_by: &[],
+            order_by: &[],
+            where_cl: WhereType::Empty,
+            having: WhereType::Empty,
+            limit: LimitType::Empty,
+            offset: OffsetType::Empty,
+            for_cl: ForType::Empty
+        };
+
+        let union = Union {
+            left: &query,
+            right: &query,
+            mode: UnionType::Simple
+        };
+
+        let expected = {
+            "SELECT * FROM test_table \
+            UNION \
+            SELECT * FROM test_table".to_string()
+        };
+        assert_eq!(union.to_sql(), expected);
+    }
+
+    #[test]
+    fn test_union_all() {
+        let query = Query {
+            select: SelectType::All,
+            distinct: DistinctType::Empty,
+            from: "test_table",
+            joins: &[],
+            group_by: &[],
+            order_by: &[],
+            where_cl: WhereType::Empty,
+            having: WhereType::Empty,
+            limit: LimitType::Empty,
+            offset: OffsetType::Empty,
+            for_cl: ForType::Empty
+        };
+
+        let union = Union {
+            left: &query,
+            right: &query,
+            mode: UnionType::All
+        };
+
+        let expected = {
+            "SELECT * FROM test_table \
+            UNION ALL \
+            SELECT * FROM test_table".to_string()
+        };
+        assert_eq!(union.to_sql(), expected);
+    }
+
+    #[test]
+    fn test_nested() {
+        let query = Query {
+            select: SelectType::All,
+            distinct: DistinctType::Empty,
+            from: "test_table",
+            joins: &[],
+            group_by: &[],
+            order_by: &[],
+            where_cl: WhereType::Empty,
+            having: WhereType::Empty,
+            limit: LimitType::Empty,
+            offset: OffsetType::Empty,
+            for_cl: ForType::Empty
+        };
+
+        let pre_union = Union {
+            left: &query,
+            right: &query,
+            mode: UnionType::Simple
+        };
+
+        let union = Union {
+            left: &pre_union,
+            right: &query,
+            mode: UnionType::All
+        };
+
+        let expected = {
+            "SELECT * FROM test_table \
+            UNION \
+            SELECT * FROM test_table \
+            UNION ALL \
+            SELECT * FROM test_table".to_string()
+        };
+        assert_eq!(union.to_sql(), expected);
+    }
+}

--- a/src/where_cl.rs
+++ b/src/where_cl.rs
@@ -1,3 +1,6 @@
+use query::ToSQL;
+
+#[allow(dead_code)]
 pub enum Operator {
     And,
     Or
@@ -12,10 +15,7 @@ impl Operator {
     }
 }
 
-pub trait ToSQL {
-    fn to_sql(&self) -> String;
-}
-
+#[allow(dead_code)]
 pub struct Where<'a, T: 'a + ToSQL> {
     pub operator: Operator,
     pub clause: &'a [T]
@@ -47,6 +47,7 @@ impl<'a, T: ToSQL> ToSQL for &'a Where<'a, T>{
     }
 }
 
+#[allow(dead_code)]
 pub enum WhereType<'a> {
     Simple(&'a str),
     Extended(&'a ToSQL),
@@ -55,7 +56,8 @@ pub enum WhereType<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Operator, ToSQL, WhereType, Where};
+    use super::{Operator, Where};
+    use query::ToSQL;
 
 
     #[test]


### PR DESCRIPTION
Moved `ToSQL` into `query.rs`, removed semilocon from queries generater by `to_sql`, added 
`#[allow(dead_code)]` into stuff

Resolves #23 
